### PR TITLE
feat: 配置修改时自动更新界面

### DIFF
--- a/src/handler.js
+++ b/src/handler.js
@@ -124,6 +124,18 @@ vscode.window.onDidChangeActiveColorTheme(e => {
   })
 })
 
+vscode.workspace.onDidChangeConfiguration((e) => {
+  if(!e.affectsConfiguration('oi-runner')) return
+  conf = vscode.workspace.getConfiguration('oi-runner')
+  const curTextEditor = vscode.window.activeTextEditor
+  view.postMessage({
+    cmd: 'init',
+    langs: Object.keys(conf.get('commands')),
+    exts: conf.get('exts'),
+    doc: curTextEditor ? curTextEditor.document.fileName : ''
+  })
+});
+
 module.exports = {
   init,
   onReceiveMsg

--- a/src/runner.js
+++ b/src/runner.js
@@ -2,7 +2,6 @@ const { EventEmitter } = require('events')
 const { spawn } = require('child_process')
 const { platform } = require('process')
 const vscode = require('vscode')
-const { statfsSync } = require('fs')
 
 class Runner extends EventEmitter {
   constructor(document, config) {


### PR DESCRIPTION
修改配置文件的时候发现界面需要重开后才能更新，尝试添加了一个 listener 复制了 init 函数中 `view.postMessage` 实现了这个效果。

PS 之前没有写过 VSCode 扩展，不知道这样写有没有问题，有的话请指出 orz。